### PR TITLE
Text modes and squishing

### DIFF
--- a/doodle/__init__.py
+++ b/doodle/__init__.py
@@ -1,3 +1,3 @@
 
-from .drawables import Drawable, Container, Box, Texture, Text, SpriteText, Anchor, Axes
+from .drawables import Drawable, Container, Box, Texture, Text, SpriteText, Anchor, Axes, TextMode
 from .drawing import Drawing

--- a/doodle/drawables.py
+++ b/doodle/drawables.py
@@ -372,11 +372,6 @@ class Texture(Drawable):
 	def render(self):
 		return self.image.resize(round_tuple_values(self.draw_size), Image.ANTIALIAS)
 
-class TextMode(Enum):
-	SINGLE_LINE = auto()
-	SQUISH = auto()
-	WRAP = auto()
-
 """
 A type of <Drawable> that can draw text with fonts.
 
@@ -624,6 +619,25 @@ class SpriteFont:
 				raise ValueError(f'could not find file \'{file}\' for character \'{char}\'')
 
 		return image
+
+"""
+Display modes for <Text>.
+"""
+class TextMode(Enum):
+	"""
+	Place the text on a single line, without transformations.
+	"""
+	SINGLE_LINE = auto()
+
+	"""
+	Squish the text to fit its size if it is too big to fit.
+	"""
+	SQUISH = auto()
+
+	"""
+	Wrap the text onto multiple lines to fit its size.
+	"""
+	WRAP = auto()
 
 """
 A relative point in a box.

--- a/doodle/drawables.py
+++ b/doodle/drawables.py
@@ -384,7 +384,6 @@ When using <TextMode.SINGLE_LINE>, you should not change the width or height.
 When using <TextMode.SQUISH>, you should not change the height.
 """
 class Text(Drawable):
-	# todo: handle empty strings crashing when rendering
 	def __init__(self, fontPath='', textColour=(255, 255, 255), textSize=0, text='', mode=TextMode.SINGLE_LINE, **kwargs):
 		super(Text, self).__init__(**kwargs)
 
@@ -480,6 +479,18 @@ class Text(Drawable):
 				elif self.mode == TextMode.SQUISH:
 					self.size = (self.size[0], s[1])
 
+	@property
+	def draw_size(self):
+		size = super(Text, self).draw_size
+
+		# give the proper size when squishing so that anchor/origin still work properly
+		if self.mode == TextMode.SQUISH:
+			s = self.font.getsize(self.text)
+			if size[0] > s[0]:
+				size = (s[0], size[1])
+
+		return size
+
 	def render(self):
 		temp = Image.new('RGBA', self.font.getsize(self.text), (255, 255, 255, 0))
 		draw = ImageDraw.Draw(temp)
@@ -487,8 +498,7 @@ class Text(Drawable):
 
 		if self.mode == TextMode.SQUISH:
 			s = round_tuple_values(self.draw_size)
-			if temp.size[0] > s[0]:
-				temp = temp.resize((s[0], temp.size[1]), Image.ANTIALIAS)
+			temp = temp.resize((s[0], temp.size[1]), Image.ANTIALIAS)
 
 		return temp
 

--- a/doodle/drawables.py
+++ b/doodle/drawables.py
@@ -389,6 +389,7 @@ class Text(Drawable):
 		super(Text, self).__init__(**kwargs)
 
 		# init the parameters so we dont crash when calling <apply_size> without all the parameters set
+		self.font = None
 		self._fontPath = None
 		self.textColour = None
 		self._textSize = None
@@ -485,7 +486,7 @@ class Text(Drawable):
 		draw.text((0, 0), self.text, self.textColour, font=self.font)
 
 		if self.mode == TextMode.SQUISH:
-			s = self.draw_size
+			s = round_tuple_values(self.draw_size)
 			if temp.size[0] > s[0]:
 				temp = temp.resize((s[0], temp.size[1]), Image.ANTIALIAS)
 

--- a/doodle/drawing.py
+++ b/doodle/drawing.py
@@ -4,7 +4,7 @@ import os
 
 import xml.etree.ElementTree as ET
 
-from doodle import Drawable, Container, Box, Texture, Text, SpriteText, Anchor, Axes
+from doodle import Drawable, Container, Box, Texture, Text, SpriteText, Anchor, Axes, TextMode
 from PIL import Image
 
 """
@@ -53,6 +53,28 @@ def axes_from_string(string):
 		string = string.lower()
 		if string in axes:
 			return axes[string]
+		else:
+			return None
+	else:
+		return None
+
+"""
+Get a <TextMode> from a string.
+
+:param string: The string to parse.
+:returns: A <TextMode> if <string> matched one, or <None> if not.
+"""
+def text_mode_from_string(string):
+	if string:
+		modes = {
+			'single-line': TextMode.SINGLE_LINE,
+			'squish': TextMode.SQUISH,
+			'wrap': TextMode.WRAP,
+		}
+
+		string = string.lower()
+		if string in modes:
+			return modes[string]
 		else:
 			return None
 	else:
@@ -230,14 +252,15 @@ class TextElement(Element, Text):
 		super(Text, self).__init__()
 		super(TextElement, self).__init__(xml)
 
-		self.font = xml.get('font')
+		self.relativeFontPath = xml.get('font')
 		self.textColour = colour_from_string(xml.get('colour') or '')
 		self.textSize = int(xml.get('font-size') or 0)
 		self.text = xml.text
+		self.mode = text_mode_from_string(xml.get('mode')) or TextMode.SINGLE_LINE
 
 	def load(self, drawing):
 		self.text = drawing.format_string(self.text)
-		self.fontPath = os.path.join(drawing.path, self.font)
+		self.fontPath = os.path.join(drawing.path, self.relativeFontPath)
 
 """
 A <SpriteText> variant of <Element>.

--- a/tests.py
+++ b/tests.py
@@ -324,6 +324,8 @@ def text_test():
 						colour=(255, 255, 255),
 					),
 					Text(
+						anchor=Anchor.TOP_CENTER,
+						origin=Anchor.TOP_CENTER,
 						relativeSizeAxes=Axes.X,
 						width=1,
 						fontPath=font,
@@ -333,8 +335,8 @@ def text_test():
 						mode=TextMode.SQUISH,
 					),
 					Text(
-						anchor=Anchor.BOTTOM_LEFT,
-						origin=Anchor.BOTTOM_LEFT,
+						anchor=Anchor.BOTTOM_CENTER,
+						origin=Anchor.BOTTOM_CENTER,
 						relativeSizeAxes=Axes.X,
 						width=1,
 						fontPath=font,

--- a/tests.py
+++ b/tests.py
@@ -1,5 +1,5 @@
 
-from doodle import Drawable, Container, Box, Texture, Text, SpriteText, Anchor, Axes, Drawing
+from doodle import Drawable, Container, Box, Texture, Text, SpriteText, Anchor, Axes, Drawing, TextMode
 
 from PIL import Image
 
@@ -315,11 +315,35 @@ def text_test():
 				size=(1, 1),
 				colour=(0, 0, 0),
 			),
-			Text(
-				fontPath=font,
-				textColour=(255, 0, 0),
-				textSize=20,
-				text='top left',
+			Container(
+				size=(150, 40),
+				children=[
+					Box(
+						relativeSizeAxes=Axes.BOTH,
+						size=(1, 1),
+						colour=(255, 255, 255),
+					),
+					Text(
+						relativeSizeAxes=Axes.X,
+						width=1,
+						fontPath=font,
+						textColour=(255, 0, 0),
+						textSize=15,
+						text='top left squish to fit, squuuuish',
+						mode=TextMode.SQUISH,
+					),
+					Text(
+						anchor=Anchor.BOTTOM_LEFT,
+						origin=Anchor.BOTTOM_LEFT,
+						relativeSizeAxes=Axes.X,
+						width=1,
+						fontPath=font,
+						textColour=(255, 0, 0),
+						textSize=15,
+						text='top left squish fits',
+						mode=TextMode.SQUISH,
+					),
+				],
 			),
 			Text(
 				anchor=Anchor.TOP_RIGHT,

--- a/tests/assets/drawing.xml
+++ b/tests/assets/drawing.xml
@@ -25,6 +25,8 @@
 					<box anchor="center" origin="center" relative-size-axes="both" size="0.5" colour="00ff00"/>
 				</option>
 				<box anchor="center" origin="center" relative-size-axes="both" size="0.25" colour="00ffff"/>
+				<text relative-size-axes="x" width="1" font="concert-one.ttf" font-size="15" mode="squish" colour="000000">squuuuuuuuuuuuuuish</text>
+				<text anchor="bottom-center" origin="bottom-center" font="concert-one.ttf" font-size="15" colour="000000">not squished</text>
 			</switch>
 		</container>
 	</progress>

--- a/tests/assets/drawing.xml
+++ b/tests/assets/drawing.xml
@@ -26,7 +26,7 @@
 				</option>
 				<box anchor="center" origin="center" relative-size-axes="both" size="0.25" colour="00ffff"/>
 				<text relative-size-axes="x" width="1" font="concert-one.ttf" font-size="15" mode="squish" colour="000000">squuuuuuuuuuuuuuish</text>
-				<text anchor="bottom-center" origin="bottom-center" font="concert-one.ttf" font-size="15" colour="000000">not squished</text>
+				<text anchor="bottom-center" origin="bottom-center" relative-size-axes="x" width="1" font="concert-one.ttf" font-size="15" mode="squish" colour="000000">not squished</text>
 			</switch>
 		</container>
 	</progress>


### PR DESCRIPTION
![screen shot 2018-03-09 at 7 29 01 pm](https://user-images.githubusercontent.com/37226320/37234767-2244c41a-23d0-11e8-9f9c-736a6445b1d1.png)

Adds `Text.mode` for setting different behaviours for text (single line, squish, or wrap), and implements squishing.