### PR TITLE
Text wrapping

### DIFF
--- a/doodle/drawing.py
+++ b/doodle/drawing.py
@@ -257,6 +257,7 @@ class TextElement(Element, Text):
 		self.textSize = int(xml.get('font-size') or 0)
 		self.text = xml.text
 		self.mode = text_mode_from_string(xml.get('mode')) or TextMode.SINGLE_LINE
+		self.lineSpacing = int(xml.get('line-spacing') or 0)
 
 	def load(self, drawing):
 		self.text = drawing.format_string(self.text)

--- a/tests.py
+++ b/tests.py
@@ -347,13 +347,29 @@ def text_test():
 					),
 				],
 			),
-			Text(
+			Container(
 				anchor=Anchor.TOP_RIGHT,
 				origin=Anchor.TOP_RIGHT,
-				fontPath=font,
-				textColour=(0, 255, 0),
-				textSize=18,
-				text='top right',
+				size=(150, 100),
+				children=[
+					Box(
+						relativeSizeAxes=Axes.BOTH,
+						size=(1, 1),
+						colour=(255, 255, 255),
+					),
+					Text(
+						anchor=Anchor.TOP_CENTER,
+						origin=Anchor.TOP_CENTER,
+						relativeSizeAxes=Axes.BOTH,
+						size=(1, 1),
+						fontPath=font,
+						textColour=(255, 0, 0),
+						textSize=10,
+						text='top right top-centered wrap. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+						mode=TextMode.WRAP,
+						lineSpacing=5,
+					),
+				],
 			),
 			Text(
 				anchor=Anchor.BOTTOM_LEFT,

--- a/tests/assets/drawing.xml
+++ b/tests/assets/drawing.xml
@@ -28,6 +28,10 @@
 				<text relative-size-axes="x" width="1" font="concert-one.ttf" font-size="15" mode="squish" colour="000000">squuuuuuuuuuuuuuish</text>
 				<text anchor="bottom-center" origin="bottom-center" relative-size-axes="x" width="1" font="concert-one.ttf" font-size="15" mode="squish" colour="000000">not squished</text>
 			</switch>
+			<container anchor="bottom-left" origin="bottom-left" width="100" height="100">
+				<box relative-size-axes="both" size="1" colour="0000ff"/>
+				<text anchor="center" origin="center" relative-size-axes="both" size="1" font="concert-one.ttf" font-size="12" mode="wrap" line-spacing="3" colour="ffffff">very long, run on sentence that should wrap around and be centered horizontally.</text>
+			</container>
 		</container>
 	</progress>
 </drawing>


### PR DESCRIPTION
![screen shot 2018-03-09 at 8 53 40 pm](https://user-images.githubusercontent.com/37226320/37236220-f8aa47ea-23db-11e8-99ec-8215c9954508.png)

Implements `TextMode.WRAP` in `Text` and adds `lineSpacing` to specify the vertical spacing between lines when using wrapping.

Also documents the `Text` init params as there are quite a few now.