### PR TITLE
Add vertical align for wrapping text

### DIFF
--- a/doodle/drawables.py
+++ b/doodle/drawables.py
@@ -517,7 +517,7 @@ class Text(Drawable):
 			return temp
 
 		"""
-		Get the anchored position of an image either the X or Y axis.
+		Get the anchored position of an image on either the X or Y axis.
 
 		:param imageSize: The width or height of the image to get the position of.
 		:param parentSize: The width or height of the parent to anchor <imageSize> inside of.
@@ -556,15 +556,15 @@ class Text(Drawable):
 			textHeight = 0
 			lineImages = []
 
+			# get all the line images and the height of textImage
 			for line in textwrap.wrap(self.text, width=limit):
 				lineImage = text_image(line)
 				textHeight += lineImage.size[1] + self.lineSpacing
 				lineImages.append(lineImage)
 
-			# remove the trailing spacing if there is any
 			textHeight = max(textHeight - self.lineSpacing, 0)
-
 			textImage = Image.new('RGBA', (size[0], textHeight), (255, 255, 255, 0))
+
 			lineY = 0
 
 			for lineImage in lineImages:

--- a/tests.py
+++ b/tests.py
@@ -350,7 +350,7 @@ def text_test():
 			Container(
 				anchor=Anchor.TOP_RIGHT,
 				origin=Anchor.TOP_RIGHT,
-				size=(150, 100),
+				size=(150, 150),
 				children=[
 					Box(
 						relativeSizeAxes=Axes.BOTH,
@@ -358,14 +358,14 @@ def text_test():
 						colour=(255, 255, 255),
 					),
 					Text(
-						anchor=Anchor.TOP_CENTER,
-						origin=Anchor.TOP_CENTER,
+						anchor=Anchor.CENTER,
+						origin=Anchor.CENTER,
 						relativeSizeAxes=Axes.BOTH,
 						size=(1, 1),
 						fontPath=font,
 						textColour=(255, 0, 0),
 						textSize=10,
-						text='top right top-centered wrap. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+						text='Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. centered wrap. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.',
 						mode=TextMode.WRAP,
 						lineSpacing=5,
 					),

--- a/tests/assets/drawing.xml
+++ b/tests/assets/drawing.xml
@@ -30,7 +30,7 @@
 			</switch>
 			<container anchor="bottom-left" origin="bottom-left" width="100" height="100">
 				<box relative-size-axes="both" size="1" colour="0000ff"/>
-				<text anchor="center" origin="center" relative-size-axes="both" size="1" font="concert-one.ttf" font-size="12" mode="wrap" line-spacing="3" colour="ffffff">very long, run on sentence that should wrap around and be centered horizontally.</text>
+				<text anchor="center" origin="center" relative-size-axes="both" size="1" font="concert-one.ttf" font-size="12" mode="wrap" line-spacing="3" colour="ffffff">very long, run on sentence that should wrap around and be centered horizontally. also, it extends outside the bounds of its parent.</text>
 			</container>
 		</container>
 	</progress>


### PR DESCRIPTION
![screen shot 2018-03-10 at 6 11 06 pm](https://user-images.githubusercontent.com/37226320/37247220-6e087626-248e-11e8-90df-e62f5047a679.png)

Allows setting the vertical alignment for text in a `Text` element when using `TextMode.WRAP` using `anchor`.